### PR TITLE
Documentation: Adjusting virtualenv to use Python 3

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -47,7 +47,7 @@ Install the demo project
 Install the demo project in a temporary virtualenv for testing purpose::
 
     cd /tmp
-    virtualenv dal_env
+    virtualenv -p python3 dal_env
     source dal_env/bin/activate
     pip install django
     pip install -e git+https://github.com/yourlabs/django-autocomplete-light.git#egg=django-autocomplete-light


### PR DESCRIPTION
Django 2.0 doesn't support python 3 any more, thus we need to be sure to use python 3 in the virtual env.